### PR TITLE
Export from `mod.ts` and set as the main file

### DIFF
--- a/node-compatible/package.json
+++ b/node-compatible/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "git+https://github.com/grammyjs/rateLimiter.git"
   },
-  "main": "./out/rateLimiter.js",
+  "main": "./out/mod.js",
   "files": [
     "out/"
   ],

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,0 +1,1 @@
+export * from "./rateLimiter.ts";


### PR DESCRIPTION
- This makes the deno.land/x URL of the plugin more significant.